### PR TITLE
Fix maven artifact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ FIXME: and add an example usage that actually makes sense:
 
     $ lein interactive
 
-## Known issues
-
-* `check` stops the process because leiningen's check.clj has `System/exit` call..
-
 ## License
 
 Copyright (c) 2013-2015 Tatsuhiro Ujihisa

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A Leiningen plugin to do many wonderful things.
 
 FIXME: Use this for user-level plugins:
 
-Put `[lein-interactive "1.0.0"]` into the `:plugins` vector of your
+Put `[io.github.ujihisa/lein-interactive "1.0.0"]` into the `:plugins` vector of your
 `:user` profile, or if you are on Leiningen 1.x do `lein plugin install
 lein-interactive 1.0.0`.
 
 FIXME: Use this for project-level plugins:
 
-Put `[lein-interactive "1.0.0"]` into the `:plugins` vector of your project.clj.
+Put `[io.github.ujihisa/lein-interactive "1.0.0"]` into the `:plugins` vector of your project.clj.
 
 FIXME: and add an example usage that actually makes sense:
 


### PR DESCRIPTION
Not sure if this plugin is fully up to date to work with modern Leiningen versions, but for me it seems to be working, after I did a manual search for "lein-interactive" on clojars, to find out that the correct artifact name is now `[io.github.ujihisa/lein-interactive "1.0.0"]` not `[lein-interactive "1.0.0"]`.

Also, `check` does not seem to call `System/exit` anymore:

```
> check
Compiling namespace my.core
> version
Leiningen 2.9.1 on Java 11.0.2 OpenJDK 64-Bit Server VM
```